### PR TITLE
Added option to use my own local blocklist file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You may wish to apply some "value overrides" to the script, or delete the iptabl
   -c=CHAIN_NAME        Override default iptables chain name
   -l=URL_LIST          Override default block list URLs [careful!]
   -f=CACHE_FILE_PATH   Override default cache file path
+  -m=LOCAL_FILE_PATH   Use my own local additional block list file
   -s                   Skip failed blocklist downloads, continuing instead of aborting
   -z                   Update the blocklist from the local cache, don't download new entries
   -d                   Delete the iptables chain (removing all blocklists)

--- a/spamhaus-drop
+++ b/spamhaus-drop
@@ -19,6 +19,10 @@ URLS="https://www.spamhaus.org/drop/drop.lasso https://www.spamhaus.org/drop/edr
 # local cache copy
 CACHE_FILE="/tmp/drop.lasso"
 
+# use local block list file or option -m
+# file must start with '/etc/spamhausdrop' to prevent misuse
+LOCAL_FILE=""
+
 # iptables custom chain name
 CHAIN="Spamhaus"
 
@@ -99,6 +103,19 @@ download_rules() {
 		fi
 	done
 
+	if [ -n "$LOCAL_FILE" ]; then
+		if [ -e "$LOCAL_FILE" ]; then
+			echo "Fetching '$LOCAL_FILE' ..."
+			if [[ $LOCAL_FILE == /etc/spamhausdrop* ]] ; then
+				grep -v "^#" "$LOCAL_FILE" | tee -a "$TMP_FILE" > /dev/null
+			else
+				echo Local file does not start with "/etc/spamhausdrop"
+			fi
+		else
+			echo Local file does not exist: "$LOCAL_FILE"
+		fi
+	fi
+
 	mv -f "$TMP_FILE" "$CACHE_FILE"
 	rm -f "$TMP_FILE"
 }
@@ -153,7 +170,7 @@ if [ "$(whoami)" != "root" ]; then
 	die "You must run this command as root."
 fi
 
-while getopts "c:l:f:usodtzh" option; do
+while getopts "c:l:f:m:usodtzh" option; do
 	case "$option" in
 		c)	# override chain name
 			CHAIN="$OPTARG"
@@ -165,6 +182,10 @@ while getopts "c:l:f:usodtzh" option; do
 
 		f)  # override rule cache file path
 			CACHE_FILE="$OPTARG"
+			;;
+
+		m)  # my own block list file
+			LOCAL_FILE="$OPTARG"
 			;;
 		
 		u)  # update block list


### PR DESCRIPTION
New option "-m filename" allows to add local blocklist file.

I made it check the filename starting with `/etc/spamhausdrop` to prevent misuse, may be this is unneeded - 
but could drop other files to `/tmp/(tempfile)`, otherwise.

The file must contain lines with IP, netmask, space, semicolon like `123.234.56.0/netmask ;` (like fetched drop/edrop files) 
and may contain comments starting with "#" which are dropped.
